### PR TITLE
Create spark.bat

### DIFF
--- a/spark.bat
+++ b/spark.bat
@@ -1,0 +1,4 @@
+@ECHO OFF
+setlocal DISABLEDELAYEDEXPANSION
+SET BIN_TARGET=%~dp0/spark
+php "%BIN_TARGET%" %*


### PR DESCRIPTION
Allows the spark installer to run on Windows. Tested on Windows 10.